### PR TITLE
Fix /api/auth URLs in authentication feature docs.

### DIFF
--- a/docs-site/content/docs/features/authentication.md
+++ b/docs-site/content/docs/features/authentication.md
@@ -34,12 +34,12 @@ $ cargo loco routes
  .
  .
  .
-[POST] /auth/forgot
-[POST] /auth/login
-[POST] /auth/register
-[POST] /auth/reset
-[POST] /auth/verify
-[GET] /user/current
+[POST] /api/auth/forgot
+[POST] /api/auth/login
+[POST] /api/auth/register
+[POST] /api/auth/reset
+[POST] /api/auth/verify
+[GET] /api/user/current
  .
  .
  .
@@ -47,12 +47,12 @@ $ cargo loco routes
 
 ### Registering a New User
 
-The `/auth/register` endpoint creates a new user in the database with an `email_verification_token` for account verification. A welcome email is sent to the user with a verification link.
+The `/api/auth/register` endpoint creates a new user in the database with an `email_verification_token` for account verification. A welcome email is sent to the user with a verification link.
 
 ##### Example Curl Request:
 
 ```sh
-curl --location '127.0.0.1:3000/auth/register' \
+curl --location '127.0.0.1:3000/api/auth/register' \
      --header 'Content-Type: application/json' \
      --data-raw '{
          "name": "Loco user",
@@ -70,7 +70,7 @@ After registering a new user, use the following request to log in:
 ##### Example Curl Request:
 
 ```sh
-curl --location '127.0.0.1:3000/auth/login' \
+curl --location '127.0.0.1:3000/api/auth/login' \
      --header 'Content-Type: application/json' \
      --data-raw '{
          "email": "user@loco.rs",
@@ -101,7 +101,7 @@ Upon user registration, an email with a verification link is sent. Visiting this
 #### Example Curl request:
 
 ```sh
-curl --location '127.0.0.1:3000/auth/verify' \
+curl --location '127.0.0.1:3000/api/auth/verify' \
      --header 'Content-Type: application/json' \
      --data '{
          "token": "TOKEN"
@@ -117,7 +117,7 @@ The `forgot` endpoint requires only the user's email in the payload. An email is
 ##### Example Curl request:
 
 ```sh
-curl --location '127.0.0.1:3000/auth/forgot' \
+curl --location '127.0.0.1:3000/api/auth/forgot' \
      --header 'Content-Type: application/json' \
      --data-raw '{
          "email": "user@loco.rs"
@@ -131,7 +131,7 @@ To reset the password, send the token generated in the `forgot` endpoint along w
 ##### Example Curl request:
 
 ```sh
-curl --location '127.0.0.1:3000/auth/reset' \
+curl --location '127.0.0.1:3000/api/auth/reset' \
      --header 'Content-Type: application/json' \
      --data '{
          "token": "TOKEN",


### PR DESCRIPTION
When following the instructions at https://loco.rs/docs/features/authentication/ one is asked to:
> Create your app using the [loco-cli](https://loco.rs/docs/getting-started/tour) and select the Saas app option.

Then one should apparently expect to see:
```
[POST] /auth/forgot
[POST] /auth/login
[POST] /auth/register
[POST] /auth/reset
[POST] /auth/verify
[GET] /user/current
```

However, whether one generates a "Rest API" or "Saas app" the actual resulting output is more like this:

```
[POST] /api/auth/register
[POST] /api/auth/verify
[POST] /api/auth/login
[POST] /api/auth/forgot
[POST] /api/auth/reset
[GET] /api/user/current
```

Note the leading `/api/` in the URLs. This actually then becomes an issue when following the instructions in the article further down. However, the links are actually correct in the "API Authentication" section, they are only incorrect in the "User Password Authentication" section.

This PR corrects the incorrect URLs.